### PR TITLE
Add interrupt support

### DIFF
--- a/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
@@ -17,52 +17,52 @@ import gov.nasa.jpl.pyre.spark.tasks.TaskScope
 /**
  * Provides utilities for interrupting a task.
  *
- * For example, one may want to run a nominal task behavior, but interrupt that behavior and abort if some fault condition occurs.
+ * For example, one may want to run a nominal task behavior, but abort that behavior if some fault condition occurs.
  */
 object Interrupts {
     /**
-     * Run an interruptible task.
-     * If at any point any [interrupts] resource is true,
-     * execution of [nominalBehavior] stops and the corresponding interrupt handler is executed instead.
+     * Run a task with the option to abort.
+     * If at any point any [abortConditions] resource is true,
+     * execution of [nominalBehavior] stops and the corresponding handler is executed instead.
      */
     context (scope: TaskScope)
-    suspend fun withInterrupts(
+    suspend fun abortIf(
+        vararg abortConditions: Pair<BooleanResource, suspend context (TaskScope) () -> Unit>,
         nominalBehavior: suspend context (TaskScope) () -> Unit,
-        vararg interrupts: Pair<BooleanResource, suspend context (TaskScope) () -> Unit>,
     ) {
-        // If any interrupt is true, we've been interrupted.
-        val isInterrupted: BooleanResource = interrupts.map { it.first }.reduceOrNull { a, b -> a or b } ?: pure(false)
+        // If any abort condition is true, we've aborted.
+        val hasAborted: BooleanResource = abortConditions.map { it.first }.reduceOrNull { a, b -> a or b } ?: pure(false)
 
-        // Construct a new TaskScope, which will throw InterruptException if an interruption occurs.
+        // Construct a new TaskScope, which will throw AbortTaskException if we abort.
         // That will stop the rest of nominal behavior from executing.
-        val interruptScope = object : TaskScope by scope {
+        val abortScope = object : TaskScope by scope {
             override suspend fun <V, E> emit(cell: CellSet.CellHandle<V, E>, effect: E) {
                 scope.emit(cell, effect)
-                // It's possible that the effect we just emitted caused our own interrupt condition to fire!
-                if (isInterrupted.getValue()) throw InterruptException()
+                // It's possible that the effect we just emitted caused our own abort condition to fire!
+                if (hasAborted.getValue()) throw AbortTaskException()
             }
 
             override suspend fun delay(time: Duration) {
-                // Convert simple delay to a condition await, so we can combine it with interrupt condition
+                // Convert simple delay to a condition await, so we can combine it with abort condition
                 await(simulationClock greaterThanOrEquals (simulationClock.getValue() + time))
             }
 
             override suspend fun await(condition: () -> Condition) {
-                // Await either the desired condition or an interruption, whichever is earlier.
-                scope.await(condition or whenTrue(isInterrupted))
-                // Check why we stopped, and handle a possible interruption.
-                if (isInterrupted.getValue()) throw InterruptException()
+                // Await either the desired condition or an abort, whichever is earlier.
+                scope.await(condition or whenTrue(hasAborted))
+                // Check why we stopped, and handle a possible abort.
+                if (hasAborted.getValue()) throw AbortTaskException()
             }
         }
 
         try {
-            // Run the nominal behavior using the interrupt-aware task scope
-            nominalBehavior(interruptScope)
-        } catch (_ : InterruptException) {
-            // If the nominal behavior is interrupted, find which interrupt occurred and run its handler
-            interrupts.first { it.first.getValue() }.second(scope)
+            // Run the nominal behavior using the abort-aware task scope
+            nominalBehavior(abortScope)
+        } catch (_ : AbortTaskException) {
+            // If the nominal behavior is aborted, find which abort condition occurred and run its handler
+            abortConditions.first { it.first.getValue() }.second(scope)
         }
     }
 
-    private class InterruptException : RuntimeException()
+    private class AbortTaskException : RuntimeException()
 }

--- a/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
@@ -1,0 +1,68 @@
+package gov.nasa.jpl.pyre.flame.interrupts
+
+import gov.nasa.jpl.pyre.ember.CellSet
+import gov.nasa.jpl.pyre.ember.Condition
+import gov.nasa.jpl.pyre.ember.Duration
+import gov.nasa.jpl.pyre.ember.plus
+import gov.nasa.jpl.pyre.spark.resources.discrete.BooleanResource
+import gov.nasa.jpl.pyre.spark.resources.discrete.BooleanResourceOperations.or
+import gov.nasa.jpl.pyre.spark.resources.discrete.DiscreteResourceMonad.pure
+import gov.nasa.jpl.pyre.spark.resources.getValue
+import gov.nasa.jpl.pyre.spark.resources.timer.TimerResourceOperations.greaterThanOrEquals
+import gov.nasa.jpl.pyre.spark.tasks.Reactions.await
+import gov.nasa.jpl.pyre.spark.tasks.Reactions.or
+import gov.nasa.jpl.pyre.spark.tasks.Reactions.whenTrue
+import gov.nasa.jpl.pyre.spark.tasks.TaskScope
+
+/**
+ * Provides utilities for interrupting a task.
+ *
+ * For example, one may want to run a nominal task behavior, but interrupt that behavior and abort if some fault condition occurs.
+ */
+object Interrupts {
+    /**
+     * Run an interruptible task.
+     * If at any point any [interrupts] resource is true,
+     * execution of [nominalBehavior] stops and the corresponding interrupt handler is executed instead.
+     */
+    context (scope: TaskScope)
+    suspend fun withInterrupts(
+        nominalBehavior: suspend context (TaskScope) () -> Unit,
+        vararg interrupts: Pair<BooleanResource, suspend context (TaskScope) () -> Unit>,
+    ) {
+        // If any interrupt is true, we've been interrupted.
+        val isInterrupted: BooleanResource = interrupts.map { it.first }.reduceOrNull { a, b -> a or b } ?: pure(false)
+
+        // Construct a new TaskScope, which will throw InterruptException if an interruption occurs.
+        // That will stop the rest of nominal behavior from executing.
+        val interruptScope = object : TaskScope by scope {
+            override suspend fun <V, E> emit(cell: CellSet.CellHandle<V, E>, effect: E) {
+                scope.emit(cell, effect)
+                // It's possible that the effect we just emitted caused our own interrupt condition to fire!
+                if (isInterrupted.getValue()) throw InterruptException()
+            }
+
+            override suspend fun delay(time: Duration) {
+                // Convert simple delay to a condition await, so we can combine it with interrupt condition
+                await(simulationClock greaterThanOrEquals (simulationClock.getValue() + time))
+            }
+
+            override suspend fun await(condition: () -> Condition) {
+                // Await either the desired condition or an interruption, whichever is earlier.
+                scope.await(condition or whenTrue(isInterrupted))
+                // Check why we stopped, and handle a possible interruption.
+                if (isInterrupted.getValue()) throw InterruptException()
+            }
+        }
+
+        try {
+            // Run the nominal behavior using the interrupt-aware task scope
+            nominalBehavior(interruptScope)
+        } catch (_ : InterruptException) {
+            // If the nominal behavior is interrupted, find which interrupt occurred and run its handler
+            interrupts.first { it.first.getValue() }.second(scope)
+        }
+    }
+
+    private class InterruptException : RuntimeException()
+}

--- a/src/main/kotlin/gov/nasa/jpl/pyre/flame/reporting/ReportHandling.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/flame/reporting/ReportHandling.kt
@@ -74,7 +74,7 @@ object ReportHandling {
     /**
      * Split channels out according to a hierarchical structure.
      *
-     * By default, channel names are split by backslash (/), the default delimiter used by [gov.nasa.jpl.pyre.flame.tasks.subContext].
+     * By default, channel names are split by backslash (/), the default delimiter used by [gov.nasa.jpl.pyre.spark.tasks.InitScope.Companion.subContext].
      *
      * Use [HierarchicalReportingStructure.reportTo] and [HierarchicalReportingStructure.split] to construct the handler.
      */

--- a/src/test/kotlin/gov/nasa/jpl/pyre/flame/interrupts/InterruptsTest.kt
+++ b/src/test/kotlin/gov/nasa/jpl/pyre/flame/interrupts/InterruptsTest.kt
@@ -1,0 +1,151 @@
+package gov.nasa.jpl.pyre.flame.interrupts
+
+import gov.nasa.jpl.pyre.ember.Duration.Companion.MINUTE
+import gov.nasa.jpl.pyre.ember.times
+import gov.nasa.jpl.pyre.ember.toKotlinDuration
+import gov.nasa.jpl.pyre.flame.interrupts.Interrupts.withInterrupts
+import gov.nasa.jpl.pyre.flame.testing.UnitTesting.runUnitTest
+import gov.nasa.jpl.pyre.spark.resources.discrete.DiscreteResourceOperations.discreteResource
+import gov.nasa.jpl.pyre.spark.resources.discrete.DiscreteResourceOperations.set
+import gov.nasa.jpl.pyre.spark.resources.discrete.MutableBooleanResource
+import gov.nasa.jpl.pyre.spark.tasks.InitScope
+import gov.nasa.jpl.pyre.spark.tasks.ResourceScope.Companion.now
+import gov.nasa.jpl.pyre.spark.tasks.TaskScope
+import gov.nasa.jpl.pyre.spark.tasks.TaskScope.Companion.delay
+import gov.nasa.jpl.pyre.spark.tasks.TaskScope.Companion.spawn
+import gov.nasa.jpl.pyre.spark.tasks.task
+import org.junit.jupiter.api.Test
+import kotlin.test.DefaultAsserter.fail
+import kotlin.test.assertEquals
+import kotlin.test.fail
+import kotlin.time.Instant
+
+class InterruptsTest {
+    private class TestModel(context: InitScope) {
+        val flag1: MutableBooleanResource
+        val flag2: MutableBooleanResource
+
+        init {
+            with (context) {
+                flag1 = discreteResource("flag1", false)
+                flag2 = discreteResource("flag2", false)
+            }
+        }
+    }
+
+    private val start = Instant.parse("2025-01-01T00:00:00Z")
+    private fun runUnitTest(testTask: suspend context(TaskScope) (TestModel) -> Unit) {
+        runUnitTest(
+            start,
+            ::TestModel,
+            testTask,
+        )
+    }
+
+    @Test
+    fun interruptable_task_without_interrupts_runs_to_completion() {
+        var nominalTaskComplete = false
+        runUnitTest {
+            withInterrupts({
+                delay(10 * MINUTE)
+                nominalTaskComplete = true
+            })
+        }
+        assert(nominalTaskComplete)
+    }
+
+    @Test
+    fun interruptable_task_runs_synchronously() {
+        runUnitTest {
+            assertEquals(start, now())
+            withInterrupts({
+                delay(10 * MINUTE)
+            })
+            assertEquals(start + (10 * MINUTE).toKotlinDuration(), now())
+        }
+    }
+
+    @Test
+    fun interruptable_task_with_no_interruptions_runs_to_completion() {
+        var nominalTaskComplete = false
+        runUnitTest {
+            withInterrupts(
+                {
+                    delay(10 * MINUTE)
+                    nominalTaskComplete = true
+                },
+                it.flag1 to { fail() },
+                it.flag2 to { fail() },
+            )
+        }
+        assert(nominalTaskComplete)
+    }
+
+    @Test
+    fun interruptions_stop_nominal_behavior_and_run_interrupt_handler() {
+        var interruptHandled = false
+        runUnitTest {
+            spawn("Cause Interruption", task {
+                delay(5 * MINUTE)
+                it.flag1.set(true)
+            })
+            withInterrupts(
+                {
+                    delay(10 * MINUTE)
+                    fail()
+                },
+                it.flag1 to {
+                    assertEquals(start + (5 * MINUTE).toKotlinDuration(), now())
+                    interruptHandled = true
+                },
+                it.flag2 to { fail() },
+            )
+            // Delay longer than any time above, to make sure we don't have some background task running that shouldn't be there.
+            // If there is, it'll hit the end and fail by 30 minutes.
+            delay(30 * MINUTE)
+        }
+        assert(interruptHandled)
+    }
+
+    @Test
+    fun interrupt_handlers_run_synchronously() {
+        runUnitTest {
+            spawn("Cause Interruption", task {
+                delay(5 * MINUTE)
+                it.flag1.set(true)
+            })
+            withInterrupts(
+                {
+                    delay(10 * MINUTE)
+                    fail()
+                },
+                it.flag1 to {
+                    delay(2 * MINUTE)
+                },
+                it.flag2 to { fail() },
+            )
+            assertEquals(start + (7 * MINUTE).toKotlinDuration(), now())
+        }
+    }
+
+    @Test
+    fun interruptions_from_interrupt_handler_dont_trigger_another_interrupt_handler() {
+        runUnitTest {
+            spawn("Cause Interruption", task {
+                delay(5 * MINUTE)
+                it.flag1.set(true)
+            })
+            withInterrupts(
+                {
+                    delay(10 * MINUTE)
+                    fail()
+                },
+                it.flag1 to {
+                    it.flag2.set(true)
+                    delay(2 * MINUTE)
+                },
+                it.flag2 to { fail() },
+            )
+        }
+    }
+}


### PR DESCRIPTION
Adds a wrapper withInterrupts, which can be used to run a tasks while monitoring for "interrupts". An interrupt here is an arbitrary boolean resource, and is handled by an arbitrary task. Multiple distinct interrupts may be specified, and the appropriate handler will be dispatched should an interrupt occur. When an interrupt occurs, execution of the nominal task halts.