### PR TITLE
Remove effect type parameter from Cell

### DIFF
--- a/src/main/kotlin/gov/nasa/jpl/pyre/ember/BasicInitScope.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/ember/BasicInitScope.kt
@@ -5,18 +5,18 @@ package gov.nasa.jpl.pyre.ember
  * Note that this is the only time we're allowed to allocate cells.
  */
 interface BasicInitScope {
-    fun <T: Any, E> allocate(cell: Cell<T, E>): CellSet.CellHandle<T, E>
+    fun <T: Any> allocate(cell: Cell<T>): CellSet.CellHandle<T>
     fun <T> spawn(name: String, step: () -> Task.PureStepResult<T>)
-    fun <T, E> read(cell: CellSet.CellHandle<T, E>): T
+    fun <T> read(cell: CellSet.CellHandle<T>): T
 
     companion object {
         context (scope: BasicInitScope)
-        fun <T: Any, E> allocate(cell: Cell<T, E>): CellSet.CellHandle<T, E> = scope.allocate(cell)
+        fun <T: Any> allocate(cell: Cell<T>): CellSet.CellHandle<T> = scope.allocate(cell)
 
         context (scope: BasicInitScope)
         fun <T> spawn(name: String, step: () -> Task.PureStepResult<T>) = scope.spawn(name, step)
 
         context (scope: BasicInitScope)
-        fun <T, E> read(cell: CellSet.CellHandle<T, E>): T = scope.read(cell)
+        fun <T> read(cell: CellSet.CellHandle<T>): T = scope.read(cell)
     }
 }

--- a/src/main/kotlin/gov/nasa/jpl/pyre/ember/Cell.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/ember/Cell.kt
@@ -2,17 +2,12 @@ package gov.nasa.jpl.pyre.ember
 
 import kotlin.reflect.KType
 
-data class Cell<T, E>(
+typealias Effect<T> = (T) -> T
+
+data class Cell<T>(
     val name: String,
     val value: T,
     val valueType: KType,
     val stepBy: (T, Duration) -> T,
-    val applyEffect: (T, E) -> T,
-    val effectTrait: EffectTrait<E>,
-) {
-    interface EffectTrait<E> {
-        fun empty(): E
-        fun sequential(first: E, second: E): E
-        fun concurrent(left: E, right: E): E
-    }
-}
+    val mergeConcurrentEffects: (Effect<T>, Effect<T>) -> Effect<T>,
+)

--- a/src/main/kotlin/gov/nasa/jpl/pyre/ember/CellSet.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/ember/CellSet.kt
@@ -1,53 +1,54 @@
 package gov.nasa.jpl.pyre.ember
 
+import gov.nasa.jpl.pyre.coals.andThen
 import kotlin.reflect.KType
 
 @Suppress("UNCHECKED_CAST")
 class CellSet private constructor(
-    private val map: MutableMap<CellHandle<*, *>, CellState<*, *>>
+    private val map: MutableMap<CellHandle<*>, CellState<*>>
 ) {
     // CellHandle is class, not data class, because we *want* to use object-identity equality
-    class CellHandle<T, E>(val name: String, val valueType: KType) {
+    class CellHandle<T>(val name: String, val valueType: KType) {
         override fun toString() = name
     }
-    data class CellState<T, E>(val cell: Cell<T, E>, val effect: E?)
+    data class CellState<T>(val cell: Cell<T>, val effect: Effect<T>?)
 
     constructor() : this(mutableMapOf())
 
-    fun <T: Any, E> allocate(cell: Cell<T, E>) =
-        CellHandle<T, E>(cell.name, cell.valueType)
+    fun <T: Any> allocate(cell: Cell<T>) =
+        CellHandle<T>(cell.name, cell.valueType)
             .also { map[it] = CellState(cell, null) }
 
-    operator fun <T, E> get(cellHandle: CellHandle<T, E>): Cell<T, E> {
-        val cellState = map[cellHandle] as CellState<T, E>
+    operator fun <T> get(cellHandle: CellHandle<T>): Cell<T> {
+        val cellState = map[cellHandle] as CellState<T>
         val cell = cellState.cell
         return cell.copy(value = cellState.getValue())
     }
 
-    private fun <T, E> CellState<T, E>.getValue(): T {
-        return effect?.let { cell.applyEffect(cell.value, it) } ?: cell.value
+    private fun <T> CellState<T>.getValue(): T {
+        return effect?.let { it(cell.value) } ?: cell.value
     }
 
-    fun <T, E> emit(cellHandle: CellHandle<T, E>, effect: E) =
-        map.compute(cellHandle) { _, cellState -> (cellState as CellState<T, E>)
-            .copy(effect = cellState.effect?.let { cellState.cell.effectTrait.sequential(it, effect) } ?: effect) }
+    fun <T> emit(cellHandle: CellHandle<T>, effect: Effect<T>) =
+        map.compute(cellHandle) { _, cellState -> (cellState as CellState<T>)
+            .copy(effect = cellState.effect?.let { it andThen effect } ?: effect) }
 
     fun split(): CellSet {
-        fun <T, E> collapseCellState(cs: CellState<T, E>) = CellState(
+        fun <T> collapseCellState(cs: CellState<T>) = CellState(
             cs.cell.copy(value=cs.getValue()),
             null)
         return CellSet(map.mapValuesTo(mutableMapOf()) { (_, cellState) -> collapseCellState(cellState) })
     }
 
     fun save(finconCollector: FinconCollector) {
-        fun <T, E> saveCell(state: CellState<T, E>) = with(state.cell) {
+        fun <T> saveCell(state: CellState<T>) = with(state.cell) {
             finconCollector.within(name).report(state.getValue(), valueType)
         }
         map.values.forEach { saveCell(it) }
     }
 
     fun restore(inconProvider: InconProvider) {
-        fun <T, E> restoreCell(handle: CellHandle<T, E>) = with(this[handle]) {
+        fun <T> restoreCell(handle: CellHandle<T>) = with(this[handle]) {
             // If incon is missing, ignore it and move on
             inconProvider.within(name).provide<T>(valueType)?.let {
                 map[handle] = CellState(copy(value=it), null)
@@ -57,29 +58,29 @@ class CellSet private constructor(
     }
 
     fun stepBy(delta: Duration) {
-        fun <T, E> stepCell(state: CellState<T, E>) = with(state.cell) {
-            CellState(copy(value = stepBy(state.getValue(), delta)), effectTrait.empty())
+        fun <T> stepCell(state: CellState<T>) = with(state.cell) {
+            CellState(copy(value = stepBy(state.getValue(), delta)), null)
         }
         map.replaceAll { _, state -> stepCell(state) }
     }
 
     companion object {
         fun join(cellSets: Collection<CellSet>): CellSet {
-            val mergedMap: MutableMap<CellHandle<*, *>, CellState<*, *>> = mutableMapOf()
+            val mergedMap: MutableMap<CellHandle<*>, CellState<*>> = mutableMapOf()
             for (cs in cellSets) {
                 cs.map.forEach { (handle, state) -> mergedMap.merge(handle, state) { s1, s2 -> join(s1, s2) } }
             }
             return CellSet(mergedMap)
         }
 
-        private fun <T, E> join(s1: CellState<T, E>, s2: CellState<*, *>): CellState<T, E> {
+        private fun <T> join(s1: CellState<T>, s2: CellState<*>): CellState<T> {
             // Just a sanity check - this could be omitted for performance...
             require(s1.cell.value == s2.cell.value)
             return s1.copy(effect = s1.effect?.let { e1 ->
                 s2.effect?.let { e2 ->
-                    s1.cell.effectTrait.concurrent(e1, e2 as E)
+                    s1.cell.mergeConcurrentEffects(e1, e2 as Effect<T>)
                 } ?: e1
-            } ?: (s2.effect as E?))
+            } ?: (s2.effect as Effect<T>?))
         }
     }
 }

--- a/src/main/kotlin/gov/nasa/jpl/pyre/ember/Condition.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/ember/Condition.kt
@@ -10,7 +10,7 @@ sealed interface Condition {
     data class UnsatisfiedUntil(val time: Duration?) : ConditionResult {
         override fun toString(): String = "UnsatisfiedUntil(${time ?: "FOREVER"})"
     }
-    data class Read<V>(val cell: CellSet.CellHandle<V, *>, val continuation: (V) -> Condition) : Condition {
+    data class Read<V>(val cell: CellSet.CellHandle<V>, val continuation: (V) -> Condition) : Condition {
         override fun toString() = "Read(${cell.name}, ...)"
     }
 

--- a/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/flame/interrupts/Interrupts.kt
@@ -3,6 +3,7 @@ package gov.nasa.jpl.pyre.flame.interrupts
 import gov.nasa.jpl.pyre.ember.CellSet
 import gov.nasa.jpl.pyre.ember.Condition
 import gov.nasa.jpl.pyre.ember.Duration
+import gov.nasa.jpl.pyre.ember.Effect
 import gov.nasa.jpl.pyre.ember.plus
 import gov.nasa.jpl.pyre.spark.resources.discrete.BooleanResource
 import gov.nasa.jpl.pyre.spark.resources.discrete.BooleanResourceOperations.or
@@ -36,7 +37,7 @@ object Interrupts {
         // Construct a new TaskScope, which will throw AbortTaskException if we abort.
         // That will stop the rest of nominal behavior from executing.
         val abortScope = object : TaskScope by scope {
-            override suspend fun <V, E> emit(cell: CellSet.CellHandle<V, E>, effect: E) {
+            override suspend fun <V> emit(cell: CellSet.CellHandle<V>, effect: Effect<V>) {
                 scope.emit(cell, effect)
                 // It's possible that the effect we just emitted caused our own abort condition to fire!
                 if (hasAborted.getValue()) throw AbortTaskException()

--- a/src/main/kotlin/gov/nasa/jpl/pyre/flame/plans/PlanSimulation.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/flame/plans/PlanSimulation.kt
@@ -72,13 +72,13 @@ class PlanSimulation<M> {
         val initContext = state.initScope()
         val startupTasks: MutableList<Pair<String, suspend context (TaskScope) () -> Unit>> = mutableListOf()
         sparkScope = object : InitScope {
-            override fun <T : Any, E> allocate(cell: Cell<T, E>): CellSet.CellHandle<T, E> =
+            override fun <T : Any> allocate(cell: Cell<T>): CellSet.CellHandle<T> =
                 initContext.allocate(cell.copy(name = "/${cell.name}"))
 
             override fun <T> spawn(name: String, step: () -> Task.PureStepResult<T>) =
                 initContext.spawn("/$name", step)
 
-            override fun <T, E> read(cell: CellSet.CellHandle<T, E>): T =
+            override fun <T> read(cell: CellSet.CellHandle<T>): T =
                 initContext.read(cell)
 
             override fun onStartup(name: String, block: suspend TaskScope.() -> Unit) {

--- a/src/main/kotlin/gov/nasa/jpl/pyre/spark/tasks/CoroutineScopes.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/spark/tasks/CoroutineScopes.kt
@@ -4,6 +4,7 @@ import gov.nasa.jpl.pyre.ember.Duration
 import gov.nasa.jpl.pyre.ember.CellSet.CellHandle
 import gov.nasa.jpl.pyre.ember.Condition
 import gov.nasa.jpl.pyre.ember.Condition.ConditionResult
+import gov.nasa.jpl.pyre.ember.Effect
 import gov.nasa.jpl.pyre.ember.PureTaskStep
 import gov.nasa.jpl.pyre.ember.Task
 import gov.nasa.jpl.pyre.ember.Task.PureStepResult.*
@@ -49,7 +50,7 @@ private class ConditionBuilder(
     private val start: Continuation<Unit> = block.createCoroutineUnintercepted(this, this)
     private var nextResult: Condition? = null
 
-    override suspend fun <V, E> read(cell: CellHandle<V, E>) =
+    override suspend fun <V> read(cell: CellHandle<V>) =
         suspendCoroutineUninterceptedOrReturn { c ->
             nextResult = Condition.Read(cell) { value ->
                 nextResult = null
@@ -131,7 +132,7 @@ private class TaskBuilder<T>(
     private val start: Continuation<Unit> = block.createCoroutineUnintercepted(this, this)
     private var nextResult: Task.PureStepResult<T>? = null
 
-    override suspend fun <V, E> read(cell: CellHandle<V, E>): V =
+    override suspend fun <V> read(cell: CellHandle<V>): V =
         suspendCoroutineUninterceptedOrReturn { c ->
             nextResult = Read(cell) { value ->
                 nextResult = null
@@ -141,7 +142,7 @@ private class TaskBuilder<T>(
             COROUTINE_SUSPENDED
         }
 
-    override suspend fun <V, E> emit(cell: CellHandle<V, E>, effect: E) =
+    override suspend fun <V> emit(cell: CellHandle<V>, effect: Effect<V>) =
         suspendCoroutineUninterceptedOrReturn { c ->
             nextResult = Emit(cell, effect, continueWith(c))
             COROUTINE_SUSPENDED


### PR DESCRIPTION
Removes the "E" type parameter for effects from Cell. In theory, this allows for objects simpler than a generic function to be used as effects on a cell. Again in theory, such simpler objects could be more efficient than a generic function effect on cells with lots of effects.

In practice, this is almost never used, as most cells have very few effects, and the remainder are often efficient enough just by choosing commuting or noncommuting effect traits, rather than autoEffects.

In order to simplify the kernel code, removes the "E" type parameter, forcing all cells to use generic function effects. This cascades into removing that type parameter from other types and methods, as well as reducing the effect trait down to just the concurrent effect merge function.

Closes #10 