### PR TITLE
Replace onStartup tasks with reporting directly during init

### DIFF
--- a/src/main/kotlin/gov/nasa/jpl/pyre/kernel/BasicInitScope.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/kernel/BasicInitScope.kt
@@ -17,6 +17,7 @@ interface BasicInitScope {
     ): Cell<T>
     fun <T> spawn(name: Name, step: PureTaskStep<T>)
     fun <T> read(cell: Cell<T>): T
+    fun <T> report(value: T, type: KType)
 
     companion object {
         context (scope: BasicInitScope)
@@ -33,5 +34,8 @@ interface BasicInitScope {
 
         context (scope: BasicInitScope)
         fun <T> read(cell: Cell<T>): T = scope.read(cell)
+
+        context (scope: BasicInitScope)
+        fun <T> report(value: T, type: KType) = scope.report(value, type)
     }
 }

--- a/src/main/kotlin/gov/nasa/jpl/pyre/kernel/InconProvider.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/kernel/InconProvider.kt
@@ -23,5 +23,6 @@ interface InconProvider : InconProvidingContext {
             return result
         }
         fun InconProvider.within(vararg keys: String): InconProvider = within(keys.asSequence())
+        inline fun <reified T> InconProvider.provide(vararg keys: String): T? = within(*keys).provide(typeOf<T>())
     }
 }

--- a/src/main/kotlin/gov/nasa/jpl/pyre/kernel/SimpleSimulation.kt
+++ b/src/main/kotlin/gov/nasa/jpl/pyre/kernel/SimpleSimulation.kt
@@ -1,7 +1,6 @@
 package gov.nasa.jpl.pyre.kernel
 
 import gov.nasa.jpl.pyre.kernel.Duration.Companion.ZERO
-import kotlinx.coroutines.runBlocking
 
 /**
  * The minimal type of simulation, in which the entire simulation is set up "at the start".
@@ -13,19 +12,15 @@ class SimpleSimulation(setup: SimulationSetup) {
         val reportHandler: ReportHandler,
         val inconProvider: InconProvider?,
         val startingTime: Duration = ZERO,
-        val initialize: suspend context (BasicInitScope) () -> Unit,
+        val initialize: context (BasicInitScope) () -> Unit,
     )
 
     private val state: SimulationState
 
     init {
         with (setup) {
-            state = SimulationState(reportHandler)
-            // Initialize the model, which gives us cells and tasks
-            // We'll just "runBlocking" this, because we know that we won't actually block during initialization.
-            runBlocking { initialize(state.initScope()) }
-            // Restore the model if we have an incon
-            inconProvider?.let(state::restore)
+            state = SimulationState(reportHandler, inconProvider)
+            initialize(state.initScope)
         }
     }
 


### PR DESCRIPTION
This is a safer way to report initial conditions, because we don't allow an "unsafe" onStartup task to arbitrarily modify the model. To get this to work though, we need to initialize all cells with their correct value, rather than restoring them later. This requires some refactoring, but ultimately leads to cleaner code.

Closes #46 